### PR TITLE
Automatically detect available languages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 [[package]]
 name = "ironworks"
 version = "0.4.1"
-source = "git+https://github.com/ackwell/ironworks#479f1502ac975becacf33749b2c9a4465dceea77"
+source = "git+https://github.com/ackwell/ironworks#a9b40991b80f7466c2acdfbbe288e4f524a0301a"
 dependencies = [
  "binrw",
  "derivative",

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,4 +1,5 @@
 use csv::Writer;
+use ironworks::Ironworks;
 use ironworks::sestring::format::Input;
 use std::error::Error;
 use std::fs;
@@ -76,6 +77,33 @@ pub fn sheet(excel: &Excel, language: Language, sheet_name: &str) -> Result<(), 
         .expect(format!("Failed to write output file: {}", &path).as_str());
 
     return Ok(());
+}
+
+// Workaround borrowed from boilmaster to check for file existence
+// See: https://github.com/ackwell/boilmaster/blob/main/crates/bm_asset/src/service.rs
+struct FileExists;
+impl ironworks::file::File for FileExists {
+    fn read(_stream: impl ironworks::FileStream) -> Result<Self, ironworks::Error> {
+        Ok(Self)
+    }
+}
+
+/// Returns the languages available to export
+pub fn available_languages(ironworks: &Ironworks) -> Vec<Language> {
+    return ironworks
+        .file::<ironworks::file::exh::ExcelHeader>("exd/Item.exh") // Read the headers from an arbitrary sheet
+        .expect("Could not read available languages from: exd/Item.exh")
+        .languages
+        .into_iter()
+        .map(Language::from)
+        .filter(|language| {
+            // Check if the sheet exists for a given language. The Global version's `EXcelHeader`s indicates all
+            // languages that are supported, even though the files aren't present besides EN, DE, FR, and JA.
+            ironworks
+                .file::<FileExists>(&format!("exd/Item_0_{}.exd", self::language_code(language)))
+                .is_ok()
+        })
+        .collect();
 }
 
 /// Returns a short code for the given language

--- a/src/export.rs
+++ b/src/export.rs
@@ -85,9 +85,9 @@ pub fn language_code(language: &Language) -> &str {
         Language::German => "de",
         Language::French => "fr",
         Language::Japanese => "ja",
-        Language::Korean => "kr",
         Language::ChineseSimplified => "chs",
-        Language::ChineseTraditional => "cht",
+        Language::Korean => "ko",
+        Language::ChineseTraditional => "tc",
         _ => "??",
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,12 +10,33 @@ mod exd_schema;
 mod export;
 mod formatter;
 
-const LANGUAGES: [Language; 4] = [
-    Language::English,
-    Language::German,
-    Language::French,
-    Language::Japanese,
-];
+fn available_languages(ironworks: &Ironworks) -> Vec<Language> {
+    // Wokaround used by boilmaster, ironworks currently doesn't support directly checking if a file exists.
+    struct FileExists;
+    impl ironworks::file::File for FileExists {
+        fn read(_stream: impl ironworks::FileStream) -> Result<Self, ironworks::Error> {
+            Ok(Self)
+        }
+    }
+
+    ironworks
+        .file::<ironworks::file::exh::ExcelHeader>("exd/Item.exh")
+        .expect("Could not read 'exd/Item.exh'")
+        .languages
+        .into_iter()
+        .map(Language::from)
+        .filter(|language| {
+            // Check if the files actually exist. The Global version's `EXcelHeader`s indicate that
+            // all languages are supported, even though the files aren't present besides for EN, DE, FR, and JA.
+            ironworks
+                .file::<FileExists>(&format!(
+                    "exd/Item_0_{}.exd",
+                    export::language_code(language)
+                ))
+                .is_ok()
+        })
+        .collect()
+}
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
@@ -29,9 +50,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let path = Path::new(&args[1]);
 
     let ironworks = Ironworks::new().with_resource(SqPack::new(Install::at(path)));
+    let languages = available_languages(&ironworks);
     let mut excel = Excel::new(ironworks);
 
-    for language in LANGUAGES {
+    for language in languages {
         excel.set_default_language(language);
         let sheets = excel.list().expect("Could not retrieve sheet list.");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,40 +3,12 @@ use std::{env, error::Error};
 
 use ironworks::{
     Ironworks,
-    excel::{Excel, Language},
+    excel::Excel,
     sqpack::{Install, SqPack},
 };
 mod exd_schema;
 mod export;
 mod formatter;
-
-fn available_languages(ironworks: &Ironworks) -> Vec<Language> {
-    // Wokaround used by boilmaster, ironworks currently doesn't support directly checking if a file exists.
-    struct FileExists;
-    impl ironworks::file::File for FileExists {
-        fn read(_stream: impl ironworks::FileStream) -> Result<Self, ironworks::Error> {
-            Ok(Self)
-        }
-    }
-
-    ironworks
-        .file::<ironworks::file::exh::ExcelHeader>("exd/Item.exh")
-        .expect("Could not read 'exd/Item.exh'")
-        .languages
-        .into_iter()
-        .map(Language::from)
-        .filter(|language| {
-            // Check if the files actually exist. The Global version's `EXcelHeader`s indicate that
-            // all languages are supported, even though the files aren't present besides for EN, DE, FR, and JA.
-            ironworks
-                .file::<FileExists>(&format!(
-                    "exd/Item_0_{}.exd",
-                    export::language_code(language)
-                ))
-                .is_ok()
-        })
-        .collect()
-}
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
@@ -50,7 +22,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let path = Path::new(&args[1]);
 
     let ironworks = Ironworks::new().with_resource(SqPack::new(Install::at(path)));
-    let languages = available_languages(&ironworks);
+    let languages = export::available_languages(&ironworks);
     let mut excel = Excel::new(ironworks);
 
     for language in languages {
@@ -73,7 +45,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Quick debugging for schema updates
 
-    // for language in LANGUAGES {
+    // for language in languages {
     //     excel.set_default_language(language);
     //     export::sheet(&excel, language, &String::from("Mount"))?;
     // }


### PR DESCRIPTION
Adds logic to automatically detect which languages can be extracted, which makes it possible to use with non-global versions without having to modify `main.rs`. The `Item` sheet was chosen arbitrarily, any sheet with versions for different languages would work.

I also had to update ironworks to the latest commit and update/fix the language short codes for it to work correctly for all versions.